### PR TITLE
Added exact measures, stopping scroll at the last line

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Overscroll for Brackets
-A very simple extension for [Brackets](https://github.com/adobe/brackets/) to allow you to scroll below the document.
-
+A very simple extension for [Brackets](https://github.com/adobe/brackets/)
+to allow you to scroll below the document, stopping at the last line.

--- a/main.js
+++ b/main.js
@@ -2,7 +2,7 @@
 /*global define, brackets, $ */
 
 define(function (require, exports, module) {
-    'use strict';
+	'use strict';
     
 	function getAllPanes(){
 		return Array.from(document.querySelectorAll('#editor-holder .CodeMirror-wrap .CodeMirror-sizer>div'));
@@ -13,11 +13,39 @@ define(function (require, exports, module) {
 		return parseFloat(window.getComputedStyle(measure).lineHeight);
 	}
 	
+	/*
+	function getScrollAmount(pane){
+		return parseFloat(pane.style.top);
+	}
+	function setScrollAmount(pane, amount){
+		pane.style.top = amount + 'px';
+	}
+	
+	function getOffset(pane){
+		return parseFloat(pane.style.paddingBottom);
+	}
+	*/
+	function setOffset(pane, amount){
+		pane.style.paddingBottom = amount + 'px';
+	}
+	
 	var WorkspaceManager = brackets.getModule('view/WorkspaceManager');
 	
 	WorkspaceManager.on('workspaceUpdateLayout', function(event, newHeight){
 		getAllPanes().forEach(function(pane){
-			pane.style.paddingBottom = (newHeight - getLineHeight(pane) * 2) + 'px';
+			var lineHeight = getLineHeight(pane);
+			// var currentScroll = getScrollAmount(pane);
+			// var currentOffset = getOffset(pane);
+			var newOffset = (newHeight - lineHeight * 2);
+			
+			setOffset(pane, newOffset);
+			
+			// BUG: if we go from smaller screen to larger, then the editor 
+			// seemingly cannot remember the scroll position
+			// for example: we scrolled down as far as we can, top line on page
+			// is 132, if we upscale the window it will change to ~104
+			// the below line didn't work, I'm leaving it here for reference
+			// setScrollAmount(pane, currentScroll - currentOffset + newOffset);
 		});
 	});
 });

--- a/main.js
+++ b/main.js
@@ -2,12 +2,22 @@
 /*global define, brackets, $ */
 
 define(function (require, exports, module) {
-    "use strict";
+    'use strict';
     
-    var AppInit = brackets.getModule("utils/AppInit");
-    
-    // Initialize extension
-    AppInit.appReady(function () {
-	    $("<style>.CodeMirror-sizer { margin-bottom: 1000px !important }</style>").appendTo("head");
-    });
+	function getAllPanes(){
+		return Array.from(document.querySelectorAll('#editor-holder .CodeMirror-wrap .CodeMirror-sizer>div'));
+	}
+	
+	function getLineHeight(pane){
+		var measure = pane.querySelector('.CodeMirror-measure:first-child>pre>span');
+		return parseFloat(window.getComputedStyle(measure).lineHeight);
+	}
+	
+	var WorkspaceManager = brackets.getModule('view/WorkspaceManager');
+	
+	WorkspaceManager.on('workspaceUpdateLayout', function(event, newHeight){
+		getAllPanes().forEach(function(pane){
+			pane.style.paddingBottom = (newHeight - getLineHeight(pane) * 2) + 'px';
+		});
+	});
 });

--- a/main.js
+++ b/main.js
@@ -13,6 +13,11 @@ define(function (require, exports, module) {
 		return parseFloat(window.getComputedStyle(measure).lineHeight);
 	}
 	
+	function getPaneHeaderHeight(pane){
+		var header = pane.parentNode.parentNode.parentNode.parentNode.parentNode.querySelector('.pane-header');
+		return header.offsetHeight;
+	}
+	
 	/*
 	function getScrollAmount(pane){
 		return parseFloat(pane.style.top);
@@ -33,18 +38,15 @@ define(function (require, exports, module) {
 	
 	WorkspaceManager.on('workspaceUpdateLayout', function(event, newHeight){
 		getAllPanes().forEach(function(pane){
-			var lineHeight = getLineHeight(pane);
 			// var currentScroll = getScrollAmount(pane);
 			// var currentOffset = getOffset(pane);
-			var newOffset = (newHeight - lineHeight * 2);
+			var newOffset = newHeight - getLineHeight(pane) * 2 - getPaneHeaderHeight(pane);
 			
 			setOffset(pane, newOffset);
 			
-			// BUG: if we go from smaller screen to larger, then the editor 
-			// seemingly cannot remember the scroll position
-			// for example: we scrolled down as far as we can, top line on page
-			// is 132, if we upscale the window it will change to ~104
-			// the below line didn't work, I'm leaving it here for reference
+			// BUG: we have some issues with calculating top
+			// the pane isn't the only one, which has a top, plus brackets
+			// messes around with the height
 			// setScrollAmount(pane, currentScroll - currentOffset + newOffset);
 		});
 	});

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "brackets-overscroll",
     "title": "Overscroll",
-    "version": "1.0.1",
+    "version": "1.1.0",
     "description": "Allow the user to scroll below the document.",
     "homepage": "https://github.com/Emmeran/brackets-overscroll",
     "author": "Emmeran (https://github.com/Emmeran)",


### PR DESCRIPTION
Created exact measures and only allow scroll, until the file reaches the last line. Also added listener for window resizing.

This will also fix the flashing issues, because this uses padding, instead of margin.

At the moment this relies heavily on CSS, so if I find a way to get the line height/number of lines through the API, then I will update this.